### PR TITLE
Ask readers to cd into the project directory

### DIFF
--- a/manuscript/getting-started.txt
+++ b/manuscript/getting-started.txt
@@ -57,6 +57,8 @@ The **new** command will create a directory with the following structure:
 +-- vendor
 ~~~~~~~~
 
+Change directory into your project.
+
 T> We can add `--help` to any `ember` command to see available
 T> options (e.g., `ember new --help`).
 


### PR DESCRIPTION
When teaching web development classes over the years, there tended to be at least 1 student each semester who would wonder why the following commands didn't work, and it turned out they didn't change into the directory of the new project.

Since readers of this book ought to be more advanced than beginning web developers, perhaps it's fine not to give them the explicit command they need to issue. If you decide to give the command, you'll need to give a version for Unix/Linux/OS X, and another version for Windows.