### PR TITLE
fixed a syntax error from page 57 missing comma at end of state: DS.attr('string')

### DIFF
--- a/manuscript/hands-on.md
+++ b/manuscript/hands-on.md
@@ -2065,7 +2065,7 @@ export default DS.Model.extend({
   createdAt:   DS.attr('date'),
   description: DS.attr('string'),
   notes:       DS.attr('string'),
-  state:       DS.attr('string')
+  state:       DS.attr('string'),
   friend:      DS.belongsTo('friend')
 });
 ~~~~~~~~


### PR DESCRIPTION
There's a syntax error on page 57. 

```import DS from 'ember-data';
export default DS.Model.extend({
createdAt: DS.attr('date'),
description: DS.attr('string'),
notes: DS.attr('string'),
state: DS.attr('string')
friend: DS.belongsTo('friend')
});```

should read

```import DS from 'ember-data';
export default DS.Model.extend({
createdAt: DS.attr('date'),
description: DS.attr('string'),
notes: DS.attr('string'),
state: DS.attr('string'),
friend: DS.belongsTo('friend')
});```