### PR TITLE
Updated typo in ember-data chapter

### DIFF
--- a/manuscript/ember-data.md
+++ b/manuscript/ember-data.md
@@ -62,7 +62,7 @@ If we call **findAll** with a model name, then it will make a request
 to load a list of records of that type. The following is an example:
 
 ~~~~~~~~
-friends =  $E.store.findRecordAll('friend')
+friends =  $E.store.findAll('friend')
 
 XHR finished loading: GET "http://localhost:4200/api/v2/friends".
 ~~~~~~~~


### PR DESCRIPTION
Ember versions:

```
DEBUG: -------------------------------
DEBUG: Ember      : 1.13.11
DEBUG: Ember Data : 1.13.15
DEBUG: jQuery     : 1.11.3
DEBUG: -------------------------------
```

`$E.store.findRecordAll` returns undefined for me, I think you meant `#findAll`