### PR TITLE
Corrected mark-down formatting mistake

### DIFF
--- a/manuscript/hands-on.md
+++ b/manuscript/hands-on.md
@@ -1762,8 +1762,8 @@ module.exports = function(defaults) {
 **app.import** is a helper function that tells **ember CLI** to append
 **bower_components/picnic/releases/picninc.min.css** into our assets
 (we also import `plugins.min.css` since it is required by picnic).
-**By default it will put any **CSS** file we import into
-****/vendor.css** and any JavaScript file into **/vendor.js**.
+By default it will put any **CSS** file we import into
+**/vendor.css** and any JavaScript file into **/vendor.js**.
 
 If we check **app/index.html**, we'll see 2 CSS files included:
 


### PR DESCRIPTION
It looks like the pairs of ** for creating bold text were not matched up correctly (and thus literally appear in the result).